### PR TITLE
Sed Fix für Arma3

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -80,7 +80,7 @@ if [ "$VAR_A" = "arma3" ]; then
         cd game
     fi
     
-    sed_edit "server.cfg" "maxPlayers" "${VAR_D}" "=" ""
+    sed -i "server.cfg" -e "s/^maxPlayers.*$/maxPlayers      = ${VAR_D};/"
     ./arma3server -server -netlog -ip="${VAR_B}" -port="${VAR_C}" -noSound -BEPath=battleye -config=server.cfg
 fi
 


### PR DESCRIPTION
Fixed Sed damit in der server.cfg von Arma3 die MaxPlayers richtig angepasst werden. Hat davor nicht funktioniert mit einer Standard Arma3 server.cfg